### PR TITLE
metainfo: Expand and modernize

### DIFF
--- a/com.rustdesk.RustDesk.metainfo.xml
+++ b/com.rustdesk.RustDesk.metainfo.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>com.rustdesk.RustDesk</id>
-  <developer_name>RustDesk</developer_name>
+  <developer id="com.rustdesk">
+    <name>RustDesk</name>
+  </developer>
   <launchable type="desktop-id">com.rustdesk.RustDesk.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>AGPL-3.0-only</project_license>
   <name>RustDesk</name>
-  <summary>An open-source remote desktop application designed for self-hosting, as an alternative to TeamViewer.</summary>
+  <summary>Secure remote desktop access</summary>
   <description>
     <p>
         RustDesk is a full-featured open source remote control alternative for self-hosting and security with minimal configuration.
@@ -28,11 +30,31 @@
   </categories>
   <screenshots>
     <screenshot type="default">
+      <caption>Remote desktop session</caption>
       <image>https://user-images.githubusercontent.com/71636191/171661982-430285f0-2e12-4b1d-9957-4a58e375304d.png</image>
     </screenshot>
   </screenshots>
+  <branding>
+    <color type="primary" scheme_preference="light">#00bbe3</color>
+    <color type="primary" scheme_preference="dark">#0176fa</color>
+  </branding>
   <url type="homepage">https://rustdesk.com</url>
   <url type="bugtracker">https://github.com/rustdesk/rustdesk/issues</url>
+  <url type="faq">https://github.com/rustdesk/rustdesk/wiki/FAQ</url>
+  <url type="help">https://rustdesk.com/docs</url>
+  <url type="donation">https://ko-fi.com/rustdesk</url>
+  <url type="vcs-browser">https://github.com/rustdesk/rustdesk</url>
+  <url type="translate">https://github.com/rustdesk/rustdesk/tree/master/src/lang</url>
+  <url type="contribute">https://github.com/rustdesk/rustdesk/blob/master/docs/CONTRIBUTING.md</url>
+  <url type="contact">https://rustdesk.com/docs/en/technical-support</url>
+  <requires>
+    <display_length compare="ge">600</display_length>
+    <internet>always</internet>
+  </requires>
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+  </supports>
   <releases>
     <release version="v1.3.1" date="2024-09-20"/>
   </releases>

--- a/com.rustdesk.RustDesk.metainfo.xml
+++ b/com.rustdesk.RustDesk.metainfo.xml
@@ -35,8 +35,8 @@
     </screenshot>
   </screenshots>
   <branding>
-    <color type="primary" scheme_preference="light">#00bbe3</color>
-    <color type="primary" scheme_preference="dark">#0176fa</color>
+    <color type="primary" scheme_preference="light">#d9eaf8</color>
+    <color type="primary" scheme_preference="dark">#0160ee</color>
   </branding>
   <url type="homepage">https://rustdesk.com</url>
   <url type="bugtracker">https://github.com/rustdesk/rustdesk/issues</url>


### PR DESCRIPTION
Update and add elements to the metainfo file to improve RustDesk's
presentation in Linux app stores.

- Replace deprecated `<developer_name>` tag with new `<developer>`
- Shorten summary
- Add `<caption>` to screenshot
- Add `<branding>` colors for use in promotional banners
- Add a couple of `<url>` tags
- Add hardware support information (supported screen sizes, internet
access, input controls)

The shortening of the summary and addition of brand colors largely brings RustDesk's metainfo in line with Flathub's [quality guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines), which apps that want to be featured/promoted on the home page have to follow. I think the only blocker after this is the screenshot, which should ideally be taken on Linux, be of a single window and have built-in shadows.

Since the metainfo file should ideally reside in RustDesk's main repository, it would be good to bring these changes over once the revert made in https://github.com/rustdesk/rustdesk/pull/9585 can be undone.