### PR TITLE
Fix Flathub external data checker config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{json,xml}]
+indent_size = 2
+indent_style = space

--- a/com.rustdesk.RustDesk.json
+++ b/com.rustdesk.RustDesk.json
@@ -37,9 +37,11 @@
       ]
     },
     {
-      "name": "pam",    
+      "name": "pam",
       "buildsystem": "autotools",
-      "config-opts": [ "--disable-selinux" ],
+      "config-opts": [
+        "--disable-selinux"
+      ],
       "sources": [
         {
           "type": "archive",
@@ -67,9 +69,10 @@
           "sha256": "725f8d53b397add3fbab24f793baa086391d1bb1a03ff80ceacc4d96597d2e63",
           "dest-filename": "rustdesk.deb",
           "x-checker-data": {
-            "type": "anitya",
-            "project-id": "309593",
-            "url-template": "https://github.com/rustdesk/rustdesk/releases/download/$version/rustdesk-$version-aarch64.deb"
+            "type": "json",
+            "url": "https://api.github.com/repos/rustdesk/rustdesk/releases/latest",
+            "version-query": ".tag_name",
+            "url-query": ".assets[] | select(.name == \"rustdesk-\\($version)-aarch64.deb\").browser_download_url"
           }
         },
         {
@@ -81,9 +84,12 @@
           "sha256": "f7d675ed2160c05b2206b6b7e50a2d369b6ed7f63abe0e89b9f38f9a29793fb4",
           "dest-filename": "rustdesk.deb",
           "x-checker-data": {
-            "type": "anitya",
-            "project-id": "309593",
-            "url-template": "https://github.com/rustdesk/rustdesk/releases/download/$version/rustdesk-$version-x86_64.deb"
+            "type": "json",
+            "url": "https://api.github.com/repos/rustdesk/rustdesk/releases/latest",
+            "version-query": ".tag_name",
+            "timestamp-query": ".published_at",
+            "url-query": ".assets[] | select(.name == \"rustdesk-\\($version)-x86_64.deb\").browser_download_url",
+            "is-main-source": true
           }
         },
         {

--- a/com.rustdesk.RustDesk.metainfo.xml
+++ b/com.rustdesk.RustDesk.metainfo.xml
@@ -56,7 +56,7 @@
     <control>pointing</control>
   </supports>
   <releases>
-    <release version="v1.3.1" date="2024-09-20"/>
+    <release version="1.3.1" date="2024-09-20"/>
   </releases>
   <content_rating type="oars-1.1"/>
 </component>


### PR DESCRIPTION
The previous configuration was wrong and nonfunctional.

Now we check directly on GitHub Releases for new versions of RustDesk.

Let me know if you have any other question.