### PR TITLE
refact(socket): --socket=wayland

### DIFF
--- a/com.rustdesk.RustDesk.json
+++ b/com.rustdesk.RustDesk.json
@@ -8,6 +8,7 @@
   "rename-icon": "rustdesk",
   "finish-args": [
     "--share=ipc",
+    "--socket=wayland",
     "--socket=x11",
     "--share=network",
     "--filesystem=home",


### PR DESCRIPTION
Add --socket=wayland option for native Wayland support

- The existing `--socket=x11` option is used to capture the cursor image.
- The new `--socket=wayland` option enables Wayland-specific permissions, such as keyboard shortcut inhibition, which are not available via the X11 socket.   https://github.com/rustdesk/rustdesk/pull/14302


https://github.com/flathub/org.inkscape.Inkscape also uses both `--socket=x11` and `--socket=wayland`.

https://github.com/flathub/org.inkscape.Inkscape/blob/b2fb847d7638c0f87eb562a3f01551f8a637dfc1/org.inkscape.Inkscape.json#L10